### PR TITLE
Update installation to use git coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,13 @@ Task-based workflow management for AI agents via Model Context Protocol (MCP).
 ## Quick Start
 
 ```bash
-# Install
-git clone https://github.com/hugoduncan/mcp-tasks.git ~/projects/hugoduncan/mcp-tasks
-
 # Add to ~/.clojure/deps.edn
 {:aliases
  {:mcp-tasks
   {:replace-paths []
    :replace-deps {org.hugpduncan/mcp-tasks
-                  {:local/root "~/projects/hugoduncan/mcp-tasks"}
+                  {:git/url "https://github.com/hugoduncan/mcp-tasks"
+                   :git/sha "2d82cffb53e3f03deced02365f5be314c7377f0b"}
                   org.clojure/clojure {:mvn/version "1.12.3"}}
    :exec-fn mcp-tasks.main/start}}}
 
@@ -65,9 +63,8 @@ mcp-tasks enables you to manage development tasks in markdown files and have AI 
 See **[doc/install.md](doc/install.md)** for complete setup instructions for Claude Code, Claude Desktop, and other MCP clients.
 
 **TL;DR:**
-1. Clone repository
-2. Add `:mcp-tasks` alias to `~/.clojure/deps.edn`
-3. Configure your MCP client to run `clojure -M:mcp-tasks`
+1. Add `:mcp-tasks` alias to `~/.clojure/deps.edn` with git coordinates
+2. Configure your MCP client to run `clojure -M:mcp-tasks`
 
 ## Core Usage
 

--- a/README.md
+++ b/README.md
@@ -15,15 +15,8 @@ Task-based workflow management for AI agents via Model Context Protocol (MCP).
                   org.clojure/clojure {:mvn/version "1.12.3"}}
    :exec-fn mcp-tasks.main/start}}}
 
-# Configure Claude Code (~/.config/claude-code/mcp-config.json)
-{
-  "mcpServers": {
-    "mcp-tasks": {
-      "command": "clojure",
-      "args": ["-M:mcp-tasks"]
-    }
-  }
-}
+# Configure Claude Code
+claude mcp add mcp-tasks -- $(which clojure) -M:mcp-tasks
 
 # Initialize .mcp-tasks as a git repository
 mkdir -p .mcp-tasks/tasks .mcp-tasks/complete .mcp-tasks/prompts

--- a/doc/install.md
+++ b/doc/install.md
@@ -27,17 +27,10 @@ Add the following alias to your `~/.clojure/deps.edn` file:
 
 ### Claude Code
 
-Add to your Claude Code MCP settings (typically `~/.config/claude-code/mcp-config.json`):
+Add the mcp-tasks server using the Claude Code CLI:
 
-```json
-{
-  "mcpServers": {
-    "mcp-tasks": {
-      "command": "clojure",
-      "args": ["-M:mcp-tasks"]
-    }
-  }
-}
+```bash
+claude mcp add mcp-tasks -- $(which clojure) -M:mcp-tasks
 ```
 
 ### Claude Desktop

--- a/doc/install.md
+++ b/doc/install.md
@@ -5,17 +5,10 @@ This guide describes how to install the mcp-tasks MCP server for use with variou
 ## Prerequisites
 
 - Clojure CLI tools installed
-- Git (to clone the repository)
 
 ## Setup
 
-### 1. Clone the Repository
-
-```bash
-git clone https://github.com/hugoduncan/mcp-tasks.git ~/projects/hugoduncan/mcp-tasks
-```
-
-### 2. Configure Global Clojure Alias
+### Configure Global Clojure Alias
 
 Add the following alias to your `~/.clojure/deps.edn` file:
 
@@ -24,12 +17,11 @@ Add the following alias to your `~/.clojure/deps.edn` file:
  {:mcp-tasks
   {:replace-paths []
    :replace-deps {org.hugpduncan/mcp-tasks
-                  {:local/root "~/projects/hugoduncan/mcp-tasks"}
+                  {:git/url "https://github.com/hugoduncan/mcp-tasks"
+                   :git/sha "2d82cffb53e3f03deced02365f5be314c7377f0b"}
                   org.clojure/clojure {:mvn/version "1.12.3"}}
    :exec-fn mcp-tasks.main/start}}}
 ```
-
-**Note:** Adjust the `:local/root` path if you cloned the repository to a different location.
 
 ## Client Configuration
 
@@ -95,6 +87,6 @@ You can verify the installation by:
 
 ## Troubleshooting
 
-- **Server fails to start:** Verify that the `:local/root` path in `~/.clojure/deps.edn` points to the correct location
+- **Server fails to start:** Verify that the `:git/sha` in `~/.clojure/deps.edn` is correct and accessible
 - **Dependencies missing:** Ensure you have Clojure 1.12.3 or compatible version installed
-- **Permission issues:** Make sure the mcp-tasks directory and all files are readable by your user
+- **Git access issues:** Make sure you can access GitHub and clone repositories


### PR DESCRIPTION
## Summary
- Updated README.md and doc/install.md to use git/url and git/sha instead of local clone instructions
- Simplified installation process by removing the clone step
- Updated prerequisites and troubleshooting sections accordingly

## Changes
- README.md: Replaced clone + local/root with git coordinates using SHA 2d82cffb53e3f03deced02365f5be314c7377f0b
- doc/install.md: Removed clone step and local/root references, updated to use git coordinates
- Simplified TL;DR installation steps

## Test plan
- [x] Verify installation instructions work with fresh setup
- [x] Confirm git/sha resolves correctly
