### PR TITLE
doc: Use -X:mcp-tasks instead of -M:mcp-tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Task-based workflow management for AI agents via Model Context Protocol (MCP).
    :exec-fn mcp-tasks.main/start}}}
 
 # Configure Claude Code
-claude mcp add mcp-tasks -- $(which clojure) -M:mcp-tasks
+claude mcp add mcp-tasks -- $(which clojure) -X:mcp-tasks
 
 # Initialize .mcp-tasks as a git repository
 mkdir -p .mcp-tasks/tasks .mcp-tasks/complete .mcp-tasks/prompts
@@ -57,7 +57,7 @@ See **[doc/install.md](doc/install.md)** for complete setup instructions for Cla
 
 **TL;DR:**
 1. Add `:mcp-tasks` alias to `~/.clojure/deps.edn` with git coordinates
-2. Configure your MCP client to run `clojure -M:mcp-tasks`
+2. Configure your MCP client to run `clojure -X:mcp-tasks`
 
 ## Core Usage
 

--- a/doc/install.md
+++ b/doc/install.md
@@ -30,7 +30,7 @@ Add the following alias to your `~/.clojure/deps.edn` file:
 Add the mcp-tasks server using the Claude Code CLI:
 
 ```bash
-claude mcp add mcp-tasks -- $(which clojure) -M:mcp-tasks
+claude mcp add mcp-tasks -- $(which clojure) -X:mcp-tasks
 ```
 
 ### Claude Desktop
@@ -48,7 +48,7 @@ Add to your Claude Desktop MCP settings:
   "mcpServers": {
     "mcp-tasks": {
       "command": "clojure",
-      "args": ["-M:mcp-tasks"]
+      "args": ["-X:mcp-tasks"]
     }
   }
 }
@@ -63,7 +63,7 @@ Add to your Codex MCP configuration file (location varies by installation):
   "mcpServers": {
     "mcp-tasks": {
       "command": "clojure",
-      "args": ["-M:mcp-tasks"]
+      "args": ["-X:mcp-tasks"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- Changed installation instructions to use `-X:mcp-tasks` instead of `-M:mcp-tasks`
- Aligns with the `:exec-fn` configuration in the `:mcp-tasks` alias

## Changes
- README.md: Updated Quick Start and TL;DR sections to use `-X` flag
- doc/install.md: Updated Claude Code, Claude Desktop, and Codex examples to use `-X` flag

## Rationale
The `:mcp-tasks` alias in `deps.edn` uses `:exec-fn mcp-tasks.main/start`, which is the exec mode configuration. The `-X` flag is the correct way to invoke exec mode aliases, while `-M` is for main opts mode.

## Test plan
- [x] Verify installation works with `-X:mcp-tasks` flag
