### PR TITLE
fix: Clarify task file handling in completion instructions

### DIFF
--- a/src/mcp_tasks/prompts.clj
+++ b/src/mcp_tasks/prompts.clj
@@ -68,7 +68,7 @@
   "Generate prompt text for completing and tracking a task."
   [category]
   (format "- Move the completed task to .mcp-tasks/complete/%s.md (append to end, mark as complete with `- [x]`)
-- Remove the task from .mcp-tasks/tasks/%s.md
+- Remove the task from .mcp-tasks/tasks/%s.md (if removing the last task, leave the file empty rather than deleting it)
 - Commit the task tracking changes in the .mcp-tasks git repository
 "
           category category))


### PR DESCRIPTION
## Summary
- Updated `complete-task-prompt-text` to explicitly state that when removing the last task from a category file, the file must be left empty rather than deleted

## Changes
- Modified src/mcp_tasks/prompts.clj:64 to add clarification in parentheses about file retention

## Test plan
- [x] All tests pass