### PR TITLE
feat: add complete-task tool

### DIFF
--- a/src/mcp_tasks/main.clj
+++ b/src/mcp_tasks/main.clj
@@ -4,7 +4,8 @@
   (:require
    [mcp-clj.log :as log]
    [mcp-clj.mcp-server.core :as mcp-server]
-   [mcp-tasks.prompts :as tp]))
+   [mcp-tasks.prompts :as tp]
+   [mcp-tasks.tools :as tools]))
 
 (defn start
   "Start stdio MCP server (uses stdin/stdout)"
@@ -13,8 +14,8 @@
     (log/info :stdio-server {:msg "Starting MCP Tasks server"})
     (with-open [server (mcp-server/create-server
                         {:transport {:type :stdio}
-                         :tools     {}
-                         :prompts   (tp/prompts)})]
+                         :tools {"complete-task" tools/complete-task-tool}
+                         :prompts (tp/prompts)})]
       (log/info :stdio-server {:msg "MCP Tasks server started"})
       (.addShutdownHook
        (Runtime/getRuntime)

--- a/src/mcp_tasks/tools.clj
+++ b/src/mcp_tasks/tools.clj
@@ -5,7 +5,8 @@
    [clojure.string :as str]))
 
 (defn- read-task-file
-  "Read task file and return content as string, or empty string if file doesn't exist"
+  "Read task file and return content as string.
+  Returns an empty string if file doesn't exist"
   [file-path]
   (if (.exists (io/file file-path))
     (slurp file-path)
@@ -26,21 +27,22 @@
   "Parse markdown task list into individual task strings.
   Returns vector of task strings, each starting with '- [ ]' or '- [x]'"
   [content]
-  (let [lines (str/split-lines content)
+  (let [lines        (str/split-lines content)
         task-pattern #"^- \[([ x])\] (.*)"]
-    (loop [lines lines
+    (loop [lines        lines
            current-task []
-           tasks []]
+           tasks        []]
       (if (empty? lines)
         (if (seq current-task)
           (conj tasks (str/join "\n" current-task))
           tasks)
-        (let [line (first lines)
+        (let [line       (first lines)
               rest-lines (rest lines)]
-          (if-let [match (re-matches task-pattern line)]
+          (if (re-matches task-pattern line)
             ;; Start of new task
             (if (seq current-task)
-              (recur rest-lines [line] (conj tasks (str/join "\n" current-task)))
+              (recur rest-lines [line]
+                     (conj tasks (str/join "\n" current-task)))
               (recur rest-lines [line] tasks))
             ;; Continuation of current task or empty line
             (if (seq current-task)
@@ -48,7 +50,8 @@
               (recur rest-lines [] tasks))))))))
 
 (defn- task-matches?
-  "Check if task text starts with the given partial text (case-insensitive, ignoring whitespace)"
+  "Check if task text starts with the given partial text.
+   The test is case-insensitive and ignores whitespace."
   [task-text partial-text]
   (let [normalize #(-> % str/lower-case (str/replace #"\s+" " ") str/trim)
         task-content (-> task-text
@@ -67,45 +70,50 @@
 
 (defn complete-task-impl
   "Implementation of complete-task tool.
-  
+
   Moves first task from tasks/<category>.md to complete/<category>.md,
-  verifying it matches the provided task-text and optionally adding a completion comment."
+  verifying it matches the provided task-text and optionally adding a
+  completion comment."
   [{:keys [category task-text completion-comment]}]
   (try
-    (let [tasks-dir ".mcp-tasks/tasks"
-          complete-dir ".mcp-tasks/complete"
-          tasks-file (str tasks-dir "/" category ".md")
+    (let [tasks-dir     ".mcp-tasks/tasks"
+          complete-dir  ".mcp-tasks/complete"
+          tasks-file    (str tasks-dir "/" category ".md")
           complete-file (str complete-dir "/" category ".md")
           tasks-content (read-task-file tasks-file)]
 
       (when (str/blank? tasks-content)
         (throw (ex-info "No tasks found in category"
                         {:category category
-                         :file tasks-file})))
+                         :file     tasks-file})))
 
       (let [tasks (parse-tasks tasks-content)]
         (when (empty? tasks)
           (throw (ex-info "No tasks found in category"
                           {:category category
-                           :file tasks-file})))
+                           :file     tasks-file})))
 
         (let [first-task (first tasks)]
           (when-not (task-matches? first-task task-text)
             (throw (ex-info "First task does not match provided text"
                             {:category category
                              :expected task-text
-                             :actual first-task})))
+                             :actual   first-task})))
 
           ;; Mark task as complete and append to complete file
-          (let [completed-task (mark-complete first-task completion-comment)
-                complete-content (read-task-file complete-file)
+          (let [completed-task       (mark-complete
+                                      first-task
+                                      completion-comment)
+                complete-content     (read-task-file complete-file)
                 new-complete-content (if (str/blank? complete-content)
                                        completed-task
-                                       (str complete-content "\n" completed-task))]
+                                       (str complete-content
+                                            "\n"
+                                            completed-task))]
             (write-task-file complete-file new-complete-content))
 
           ;; Remove first task from tasks file
-          (let [remaining-tasks (rest tasks)
+          (let [remaining-tasks   (rest tasks)
                 new-tasks-content (str/join "\n" remaining-tasks)]
             (write-task-file tasks-file new-tasks-content))
 
@@ -119,16 +127,28 @@
                                (str "\nDetails: " (pr-str data))))}]
        :isError true})))
 
+(def ^:private description
+  "Complete a task by moving it from
+   .mcp-tasks/tasks/<category>.md to .mcp-tasks/complete/<category>.md.
+
+   Verifies the first task matches the provided text, marks it complete, and
+   optionally adds a completion comment.")
+
 (def complete-task-tool
   "Tool to complete a task and move it from tasks to complete directory"
-  {:name "complete-task"
-   :description "Complete a task by moving it from tasks/<category>.md to complete/<category>.md. Verifies the first task matches the provided text, marks it complete, and optionally adds a completion comment."
-   :inputSchema {:type "object"
-                 :properties {"category" {:type "string"
-                                          :description "The task category name"}
-                              "task-text" {:type "string"
-                                           :description "Partial text from the beginning of the task to verify"}
-                              "completion-comment" {:type "string"
-                                                    :description "Optional comment to append to the completed task"}}
-                 :required ["category" "task-text"]}
+  {:name           "complete-task"
+   :description    description
+   :inputSchema
+   {:type     "object"
+    :properties
+    {"category"
+     {:type        "string"
+      :description "The task category name"}
+     "task-text"
+     {:type        "string"
+      :description "Partial text from the beginning of the task to verify"}
+     "completion-comment"
+     {:type        "string"
+      :description "Optional comment to append to the completed task"}}
+    :required ["category" "task-text"]}
    :implementation complete-task-impl})

--- a/src/mcp_tasks/tools.clj
+++ b/src/mcp_tasks/tools.clj
@@ -1,0 +1,134 @@
+(ns mcp-tasks.tools
+  "Task management tools"
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]))
+
+(defn- read-task-file
+  "Read task file and return content as string, or empty string if file doesn't exist"
+  [file-path]
+  (if (.exists (io/file file-path))
+    (slurp file-path)
+    ""))
+
+(defn- write-task-file
+  "Write content to task file atomically"
+  [file-path content]
+  (let [file (io/file file-path)
+        parent (.getParentFile file)]
+    (when parent
+      (.mkdirs parent))
+    (let [temp-file (io/file (str file-path ".tmp"))]
+      (spit temp-file content)
+      (.renameTo temp-file file))))
+
+(defn- parse-tasks
+  "Parse markdown task list into individual task strings.
+  Returns vector of task strings, each starting with '- [ ]' or '- [x]'"
+  [content]
+  (let [lines (str/split-lines content)
+        task-pattern #"^- \[([ x])\] (.*)"]
+    (loop [lines lines
+           current-task []
+           tasks []]
+      (if (empty? lines)
+        (if (seq current-task)
+          (conj tasks (str/join "\n" current-task))
+          tasks)
+        (let [line (first lines)
+              rest-lines (rest lines)]
+          (if-let [match (re-matches task-pattern line)]
+            ;; Start of new task
+            (if (seq current-task)
+              (recur rest-lines [line] (conj tasks (str/join "\n" current-task)))
+              (recur rest-lines [line] tasks))
+            ;; Continuation of current task or empty line
+            (if (seq current-task)
+              (recur rest-lines (conj current-task line) tasks)
+              (recur rest-lines [] tasks))))))))
+
+(defn- task-matches?
+  "Check if task text starts with the given partial text (case-insensitive, ignoring whitespace)"
+  [task-text partial-text]
+  (let [normalize #(-> % str/lower-case (str/replace #"\s+" " ") str/trim)
+        task-content (-> task-text
+                         (str/replace #"^- \[([ x])\] " "")
+                         normalize)
+        search-text (normalize partial-text)]
+    (str/starts-with? task-content search-text)))
+
+(defn- mark-complete
+  "Mark task as complete and optionally append completion comment"
+  [task-text completion-comment]
+  (let [completed-task (str/replace task-text #"^- \[ \]" "- [x]")]
+    (if (and completion-comment (not (str/blank? completion-comment)))
+      (str completed-task "\n\n" (str/trim completion-comment))
+      completed-task)))
+
+(defn complete-task-impl
+  "Implementation of complete-task tool.
+  
+  Moves first task from tasks/<category>.md to complete/<category>.md,
+  verifying it matches the provided task-text and optionally adding a completion comment."
+  [{:keys [category task-text completion-comment]}]
+  (try
+    (let [tasks-dir ".mcp-tasks/tasks"
+          complete-dir ".mcp-tasks/complete"
+          tasks-file (str tasks-dir "/" category ".md")
+          complete-file (str complete-dir "/" category ".md")
+          tasks-content (read-task-file tasks-file)]
+
+      (when (str/blank? tasks-content)
+        (throw (ex-info "No tasks found in category"
+                        {:category category
+                         :file tasks-file})))
+
+      (let [tasks (parse-tasks tasks-content)]
+        (when (empty? tasks)
+          (throw (ex-info "No tasks found in category"
+                          {:category category
+                           :file tasks-file})))
+
+        (let [first-task (first tasks)]
+          (when-not (task-matches? first-task task-text)
+            (throw (ex-info "First task does not match provided text"
+                            {:category category
+                             :expected task-text
+                             :actual first-task})))
+
+          ;; Mark task as complete and append to complete file
+          (let [completed-task (mark-complete first-task completion-comment)
+                complete-content (read-task-file complete-file)
+                new-complete-content (if (str/blank? complete-content)
+                                       completed-task
+                                       (str complete-content "\n" completed-task))]
+            (write-task-file complete-file new-complete-content))
+
+          ;; Remove first task from tasks file
+          (let [remaining-tasks (rest tasks)
+                new-tasks-content (str/join "\n" remaining-tasks)]
+            (write-task-file tasks-file new-tasks-content))
+
+          {:content [{:type "text"
+                      :text (str "Task completed and moved to " complete-file)}]
+           :isError false})))
+    (catch Exception e
+      {:content [{:type "text"
+                  :text (str "Error: " (.getMessage e)
+                             (when-let [data (ex-data e)]
+                               (str "\nDetails: " (pr-str data))))}]
+       :isError true})))
+
+(def complete-task-tool
+  "Tool to complete a task and move it from tasks to complete directory"
+  {:name "complete-task"
+   :description "Complete a task by moving it from tasks/<category>.md to complete/<category>.md. Verifies the first task matches the provided text, marks it complete, and optionally adds a completion comment."
+   :inputSchema {:type "object"
+                 :properties {"category" {:type "string"
+                                          :description "The task category name"}
+                              "task-text" {:type "string"
+                                           :description "Partial text from the beginning of the task to verify"}
+                              "completion-comment" {:type "string"
+                                                    :description "Optional comment to append to the completed task"}}
+                 :required ["category" "task-text"]}
+   :implementation complete-task-impl})

--- a/test/mcp_tasks/tools_test.clj
+++ b/test/mcp_tasks/tools_test.clj
@@ -1,0 +1,152 @@
+(ns mcp-tasks.tools-test
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [mcp-tasks.tools :as sut]))
+
+(def ^:private test-fixtures-dir "test-resources/tools-test")
+
+(defn- cleanup-test-fixtures []
+  (let [dir (io/file test-fixtures-dir)]
+    (when (.exists dir)
+      (doseq [file (reverse (file-seq dir))]
+        (.delete file)))))
+
+(defn- setup-test-dir []
+  (cleanup-test-fixtures)
+  (.mkdirs (io/file test-fixtures-dir "tasks"))
+  (.mkdirs (io/file test-fixtures-dir "complete")))
+
+(defn- write-test-file [path content]
+  (spit (str test-fixtures-dir "/" path) content))
+
+(defn- read-test-file [path]
+  (let [file (io/file (str test-fixtures-dir "/" path))]
+    (if (.exists file)
+      (slurp file)
+      "")))
+
+(defn- with-test-files [f]
+  (with-redefs [sut/read-task-file
+                (fn [path]
+                  (read-test-file (str/replace path #"^\.mcp-tasks/" "")))
+                sut/write-task-file
+                (fn [path content]
+                  (write-test-file (str/replace path #"^\.mcp-tasks/" "")
+                                   content))]
+    (f)))
+
+(deftest moves-first-task-from-tasks-to-complete
+  ;; Tests that the complete-task-impl function correctly moves the first
+  ;; task from tasks/<category>.md to complete/<category>.md
+  (setup-test-dir)
+  (write-test-file "tasks/test.md"
+                   "- [ ] first task\n      detail line\n- [ ] second task")
+  (with-test-files
+    #(let [result (sut/complete-task-impl
+                   {:category "test"
+                    :task-text "first task"})]
+       (is (false? (:isError result)))
+       (is (= "- [x] first task\n      detail line"
+              (read-test-file "complete/test.md")))
+       (is (= "- [ ] second task"
+              (read-test-file "tasks/test.md")))))
+  (cleanup-test-fixtures))
+
+(deftest adds-completion-comment-when-provided
+  ;; Tests that completion comments are appended to completed tasks
+  (setup-test-dir)
+  (write-test-file "tasks/test.md" "- [ ] task with comment")
+  (with-test-files
+    #(let [result (sut/complete-task-impl
+                   {:category "test"
+                    :task-text "task with comment"
+                    :completion-comment "Added feature X"})]
+       (is (false? (:isError result)))
+       (is (= "- [x] task with comment\n\nAdded feature X"
+              (read-test-file "complete/test.md")))))
+  (cleanup-test-fixtures))
+
+(deftest appends-to-existing-complete-file
+  ;; Tests that completed tasks are appended to existing complete file
+  (setup-test-dir)
+  (write-test-file "tasks/test.md" "- [ ] new task")
+  (write-test-file "complete/test.md" "- [x] old task")
+  (with-test-files
+    #(let [result (sut/complete-task-impl
+                   {:category "test"
+                    :task-text "new task"})]
+       (is (false? (:isError result)))
+       (is (= "- [x] old task\n- [x] new task"
+              (read-test-file "complete/test.md")))))
+  (cleanup-test-fixtures))
+
+(deftest leaves-tasks-file-empty-when-completing-last-task
+  ;; Tests that the tasks file is left empty (not deleted) when the last
+  ;; task is completed
+  (setup-test-dir)
+  (write-test-file "tasks/test.md" "- [ ] only task")
+  (with-test-files
+    #(let [result (sut/complete-task-impl
+                   {:category "test"
+                    :task-text "only task"})]
+       (is (false? (:isError result)))
+       (is (= "" (read-test-file "tasks/test.md")))))
+  (cleanup-test-fixtures))
+
+(deftest errors-when-task-text-does-not-match
+  ;; Tests that an error is returned when the provided task text doesn't
+  ;; match the first task
+  (setup-test-dir)
+  (write-test-file "tasks/test.md" "- [ ] actual task")
+  (with-test-files
+    #(let [result (sut/complete-task-impl
+                   {:category "test"
+                    :task-text "wrong task"})]
+       (is (true? (:isError result)))
+       (is (re-find #"does not match"
+                    (get-in result [:content 0 :text])))))
+  (cleanup-test-fixtures))
+
+(deftest errors-when-category-has-no-tasks
+  ;; Tests that an error is returned when trying to complete a task in an
+  ;; empty category
+  (setup-test-dir)
+  (write-test-file "tasks/test.md" "")
+  (with-test-files
+    #(let [result (sut/complete-task-impl
+                   {:category "test"
+                    :task-text "any task"})]
+       (is (true? (:isError result)))
+       (is (re-find #"No tasks found"
+                    (get-in result [:content 0 :text])))))
+  (cleanup-test-fixtures))
+
+(deftest matches-tasks-case-insensitively
+  ;; Tests that task matching is case-insensitive
+  (setup-test-dir)
+  (write-test-file "tasks/test.md" "- [ ] Task With Capitals")
+  (with-test-files
+    #(let [result (sut/complete-task-impl
+                   {:category "test"
+                    :task-text "task with capitals"})]
+       (is (false? (:isError result)))))
+  (cleanup-test-fixtures))
+
+(deftest handles-multi-line-tasks-correctly
+  ;; Tests that multi-line tasks are handled correctly, preserving all
+  ;; continuation lines
+  (setup-test-dir)
+  (write-test-file "tasks/test.md"
+                   "- [ ] first task\n      line 2\n      line 3\n- [ ] second task")
+  (with-test-files
+    #(let [result (sut/complete-task-impl
+                   {:category "test"
+                    :task-text "first task"})]
+       (is (false? (:isError result)))
+       (is (= "- [x] first task\n      line 2\n      line 3"
+              (read-test-file "complete/test.md")))
+       (is (= "- [ ] second task"
+              (read-test-file "tasks/test.md")))))
+  (cleanup-test-fixtures))


### PR DESCRIPTION
Add complete-task tool to move completed tasks from tasks/<category>.md
to complete/<category>.md with verification and atomic file operations.