### PR TITLE
feat: add next-task and add-task tools

### DIFF
--- a/src/mcp_tasks/main.clj
+++ b/src/mcp_tasks/main.clj
@@ -14,7 +14,9 @@
     (log/info :stdio-server {:msg "Starting MCP Tasks server"})
     (with-open [server (mcp-server/create-server
                          {:transport {:type :stdio}
-                          :tools {"complete-task" tools/complete-task-tool}
+                          :tools {"complete-task" tools/complete-task-tool
+                                  "next-task" tools/next-task-tool
+                                  "add-task" tools/add-task-tool}
                           :prompts (tp/prompts)})]
       (log/info :stdio-server {:msg "MCP Tasks server started"})
       (.addShutdownHook

--- a/src/mcp_tasks/prompts.clj
+++ b/src/mcp_tasks/prompts.clj
@@ -52,6 +52,8 @@
   (format "- Read the file .mcp-tasks/tasks/%s.md
 - Find the first incomplete task (marked with `- [ ]`)
 - Show the task description
+
+You can use the `next-task` tool to retrieve the next task without executing it.
 "
           category))
 
@@ -63,10 +65,7 @@
 - Implement the solution
 - Create a git commit with the code changes in the main repository
 
-Available tools:
-- Use the `next-task` tool to retrieve the next task without executing it
-- Use the `complete-task` tool to mark a task as complete and move it to the completed archive
-- Use the `add-task` tool to add new tasks to a category
+You can use the `add-task` tool to add new tasks to a category.
 ")
 
 (defn- complete-task-prompt-text
@@ -75,6 +74,8 @@ Available tools:
   (format "- Move the completed task to .mcp-tasks/complete/%s.md (append to end, mark as complete with `- [x]`)
 - Remove the task from .mcp-tasks/tasks/%s.md (if removing the last task, leave the file empty rather than deleting it)
 - Commit the task tracking changes in the .mcp-tasks git repository
+
+You can use the `complete-task` tool to mark a task as complete and move it to the completed archive.
 "
           category category))
 

--- a/src/mcp_tasks/prompts.clj
+++ b/src/mcp_tasks/prompts.clj
@@ -62,6 +62,11 @@
 - Plan an implementation approach
 - Implement the solution
 - Create a git commit with the code changes in the main repository
+
+Available tools:
+- Use the `next-task` tool to retrieve the next task without executing it
+- Use the `complete-task` tool to mark a task as complete and move it to the completed archive
+- Use the `add-task` tool to add new tasks to a category
 ")
 
 (defn- complete-task-prompt-text

--- a/src/mcp_tasks/prompts.clj
+++ b/src/mcp_tasks/prompts.clj
@@ -50,10 +50,10 @@
   "Generate prompt text for reading the next task from a category."
   [category]
   (format "- Read the file .mcp-tasks/tasks/%s.md
-- Find the first incomplete task (marked with `- [ ]`)
-- Show the task description
 
-You can use the `next-task` tool to retrieve the next task without executing it.
+- Find the first incomplete task (marked with `- [ ]`) You can use the
+  `next-task` tool to retrieve the next task without executing it.
+- Show the task description
 "
           category))
 
@@ -71,11 +71,14 @@ You can use the `add-task` tool to add new tasks to a category.
 (defn- complete-task-prompt-text
   "Generate prompt text for completing and tracking a task."
   [category]
-  (format "- Move the completed task to .mcp-tasks/complete/%s.md (append to end, mark as complete with `- [x]`)
-- Remove the task from .mcp-tasks/tasks/%s.md (if removing the last task, leave the file empty rather than deleting it)
-- Commit the task tracking changes in the .mcp-tasks git repository
+  (format "- Move the completed task to .mcp-tasks/complete/%s.md (append to
+  end, mark as complete with `- [x]`). You can use the `complete-task` tool to
+  mark a task as complete and move it to the completed archive.
 
-You can use the `complete-task` tool to mark a task as complete and move it to the completed archive.
+- Remove the task from .mcp-tasks/tasks/%s.md (if removing the last task, leave
+  the file empty rather than deleting it)
+
+- Commit the task tracking changes in the .mcp-tasks git repository
 "
           category category))
 
@@ -122,7 +125,7 @@ You can use the `complete-task` tool to mark a task as complete and move it to t
 
 (defn prompts
   "Generate all task prompts by discovering categories and creating prompts for them.
-  
+
   Returns a map of prompt names to prompt definitions, suitable for registering
   with the MCP server."
   []

--- a/test/mcp_tasks/tools_test.clj
+++ b/test/mcp_tasks/tools_test.clj
@@ -42,119 +42,137 @@
                                    content))]
     (f)))
 
+;;; complete-task-impl tests
+
 (deftest moves-first-task-from-tasks-to-complete
   ;; Tests that the complete-task-impl function correctly moves the first
   ;; task from tasks/<category>.md to complete/<category>.md
-  (setup-test-dir)
-  (write-test-file "tasks/test.md"
-                   "- [ ] first task\n      detail line\n- [ ] second task")
-  (with-test-files
-    #(let [result (sut/complete-task-impl
-                    {:category "test"
-                     :task-text "first task"})]
-       (is (false? (:isError result)))
-       (is (= "- [x] first task\n      detail line"
-              (read-test-file "complete/test.md")))
-       (is (= "- [ ] second task"
-              (read-test-file "tasks/test.md")))))
-  (cleanup-test-fixtures))
+  (testing "complete-task"
+    (testing "moves first task from tasks to complete"
+      (setup-test-dir)
+      (write-test-file "tasks/test.md"
+                       "- [ ] first task\n      detail line\n- [ ] second task")
+      (with-test-files
+        #(let [result (sut/complete-task-impl
+                        {:category "test"
+                         :task-text "first task"})]
+           (is (false? (:isError result)))
+           (is (= "- [x] first task\n      detail line"
+                  (read-test-file "complete/test.md")))
+           (is (= "- [ ] second task"
+                  (read-test-file "tasks/test.md")))))
+      (cleanup-test-fixtures))))
 
 (deftest adds-completion-comment-when-provided
   ;; Tests that completion comments are appended to completed tasks
-  (setup-test-dir)
-  (write-test-file "tasks/test.md" "- [ ] task with comment")
-  (with-test-files
-    #(let [result (sut/complete-task-impl
-                    {:category "test"
-                     :task-text "task with comment"
-                     :completion-comment "Added feature X"})]
-       (is (false? (:isError result)))
-       (is (= "- [x] task with comment\n\nAdded feature X"
-              (read-test-file "complete/test.md")))))
-  (cleanup-test-fixtures))
+  (testing "complete-task"
+    (testing "adds completion comment when provided"
+      (setup-test-dir)
+      (write-test-file "tasks/test.md" "- [ ] task with comment")
+      (with-test-files
+        #(let [result (sut/complete-task-impl
+                        {:category "test"
+                         :task-text "task with comment"
+                         :completion-comment "Added feature X"})]
+           (is (false? (:isError result)))
+           (is (= "- [x] task with comment\n\nAdded feature X"
+                  (read-test-file "complete/test.md")))))
+      (cleanup-test-fixtures))))
 
 (deftest appends-to-existing-complete-file
   ;; Tests that completed tasks are appended to existing complete file
-  (setup-test-dir)
-  (write-test-file "tasks/test.md" "- [ ] new task")
-  (write-test-file "complete/test.md" "- [x] old task")
-  (with-test-files
-    #(let [result (sut/complete-task-impl
-                    {:category "test"
-                     :task-text "new task"})]
-       (is (false? (:isError result)))
-       (is (= "- [x] old task\n- [x] new task"
-              (read-test-file "complete/test.md")))))
-  (cleanup-test-fixtures))
+  (testing "complete-task"
+    (testing "appends to existing complete file"
+      (setup-test-dir)
+      (write-test-file "tasks/test.md" "- [ ] new task")
+      (write-test-file "complete/test.md" "- [x] old task")
+      (with-test-files
+        #(let [result (sut/complete-task-impl
+                        {:category "test"
+                         :task-text "new task"})]
+           (is (false? (:isError result)))
+           (is (= "- [x] old task\n- [x] new task"
+                  (read-test-file "complete/test.md")))))
+      (cleanup-test-fixtures))))
 
 (deftest leaves-tasks-file-empty-when-completing-last-task
   ;; Tests that the tasks file is left empty (not deleted) when the last
   ;; task is completed
-  (setup-test-dir)
-  (write-test-file "tasks/test.md" "- [ ] only task")
-  (with-test-files
-    #(let [result (sut/complete-task-impl
-                    {:category "test"
-                     :task-text "only task"})]
-       (is (false? (:isError result)))
-       (is (= "" (read-test-file "tasks/test.md")))))
-  (cleanup-test-fixtures))
+  (testing "complete-task"
+    (testing "leaves tasks file empty when completing last task"
+      (setup-test-dir)
+      (write-test-file "tasks/test.md" "- [ ] only task")
+      (with-test-files
+        #(let [result (sut/complete-task-impl
+                        {:category "test"
+                         :task-text "only task"})]
+           (is (false? (:isError result)))
+           (is (= "" (read-test-file "tasks/test.md")))))
+      (cleanup-test-fixtures))))
 
 (deftest errors-when-task-text-does-not-match
   ;; Tests that an error is returned when the provided task text doesn't
   ;; match the first task
-  (setup-test-dir)
-  (write-test-file "tasks/test.md" "- [ ] actual task")
-  (with-test-files
-    #(let [result (sut/complete-task-impl
-                    {:category "test"
-                     :task-text "wrong task"})]
-       (is (true? (:isError result)))
-       (is (re-find #"does not match"
-                    (get-in result [:content 0 :text])))))
-  (cleanup-test-fixtures))
+  (testing "complete-task"
+    (testing "errors when task text does not match"
+      (setup-test-dir)
+      (write-test-file "tasks/test.md" "- [ ] actual task")
+      (with-test-files
+        #(let [result (sut/complete-task-impl
+                        {:category "test"
+                         :task-text "wrong task"})]
+           (is (true? (:isError result)))
+           (is (re-find #"does not match"
+                        (get-in result [:content 0 :text])))))
+      (cleanup-test-fixtures))))
 
 (deftest errors-when-category-has-no-tasks
   ;; Tests that an error is returned when trying to complete a task in an
   ;; empty category
-  (setup-test-dir)
-  (write-test-file "tasks/test.md" "")
-  (with-test-files
-    #(let [result (sut/complete-task-impl
-                    {:category "test"
-                     :task-text "any task"})]
-       (is (true? (:isError result)))
-       (is (re-find #"No tasks found"
-                    (get-in result [:content 0 :text])))))
-  (cleanup-test-fixtures))
+  (testing "complete-task"
+    (testing "errors when category has no tasks"
+      (setup-test-dir)
+      (write-test-file "tasks/test.md" "")
+      (with-test-files
+        #(let [result (sut/complete-task-impl
+                        {:category "test"
+                         :task-text "any task"})]
+           (is (true? (:isError result)))
+           (is (re-find #"No tasks found"
+                        (get-in result [:content 0 :text])))))
+      (cleanup-test-fixtures))))
 
 (deftest matches-tasks-case-insensitively
   ;; Tests that task matching is case-insensitive
-  (setup-test-dir)
-  (write-test-file "tasks/test.md" "- [ ] Task With Capitals")
-  (with-test-files
-    #(let [result (sut/complete-task-impl
-                    {:category "test"
-                     :task-text "task with capitals"})]
-       (is (false? (:isError result)))))
-  (cleanup-test-fixtures))
+  (testing "complete-task"
+    (testing "matches tasks case-insensitively"
+      (setup-test-dir)
+      (write-test-file "tasks/test.md" "- [ ] Task With Capitals")
+      (with-test-files
+        #(let [result (sut/complete-task-impl
+                        {:category "test"
+                         :task-text "task with capitals"})]
+           (is (false? (:isError result)))))
+      (cleanup-test-fixtures))))
 
 (deftest handles-multi-line-tasks-correctly
   ;; Tests that multi-line tasks are handled correctly, preserving all
   ;; continuation lines
-  (setup-test-dir)
-  (write-test-file "tasks/test.md"
-                   "- [ ] first task\n      line 2\n      line 3\n- [ ] second task")
-  (with-test-files
-    #(let [result (sut/complete-task-impl
-                    {:category "test"
-                     :task-text "first task"})]
-       (is (false? (:isError result)))
-       (is (= "- [x] first task\n      line 2\n      line 3"
-              (read-test-file "complete/test.md")))
-       (is (= "- [ ] second task"
-              (read-test-file "tasks/test.md")))))
-  (cleanup-test-fixtures))
+  (testing "complete-task"
+    (testing "handles multi-line tasks correctly"
+      (setup-test-dir)
+      (write-test-file "tasks/test.md"
+                       "- [ ] first task\n      line 2\n      line 3\n- [ ] second task")
+      (with-test-files
+        #(let [result (sut/complete-task-impl
+                        {:category "test"
+                         :task-text "first task"})]
+           (is (false? (:isError result)))
+           (is (= "- [x] first task\n      line 2\n      line 3"
+                  (read-test-file "complete/test.md")))
+           (is (= "- [ ] second task"
+                  (read-test-file "tasks/test.md")))))
+      (cleanup-test-fixtures))))
 
 ;;; next-task-impl tests
 


### PR DESCRIPTION
## Summary
- Add `next-task` tool to retrieve the next task without executing it
- Add `add-task` tool to append tasks to a category
- Update prompts to reference the new tools
- Add tests for both new tools

## Changes
- `src/mcp_tasks/main.clj`: Register next-task and add-task tools
- `src/mcp_tasks/tools.clj`: Implement next-task-impl and add-task-impl
- `src/mcp_tasks/prompts.clj`: Update prompts to mention the new tools
- `test/mcp_tasks/tools_test.clj`: Add tests for next-task and add-task, standardize test structure

## Test plan
- [ ] Verify next-task returns first task when tasks exist
- [ ] Verify next-task returns status when no tasks exist
- [ ] Verify add-task creates task in empty file
- [ ] Verify add-task appends to existing tasks
- [ ] All tests pass