### PR TITLE
feat: add JAR build script with semantic versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /.mcp-tasks/
+/target/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,14 +55,11 @@ clj -T:build version
 
 - Use semantic commit messages, and semantic pull request titles
 - run `cljstyle fix` before making commits
-- run `(clj-kondo --lint src test)
-  ⎿  linting took 225ms, errors: 0, warnings: 0
-
-⏺ No clj-kondo errors found. The codebase passes linting cleanly.
-
-───────────────────────────────────────────────────────────────────────────────────────
-#  run  
-───────────────────────────────────────────────────────────────────────────────────────
-  # to memorize                                                         ⧉ In main.clj
+- run `(clj-kondo --lint src test)` before commits
 - run `clj-kondo --lint src test` before commiting
-- when merging a PR provide a clean commit message using semntic commit message style.  Do no just use the default message or a concatenation of all the commit messages.  The message should reflect the scope and logical content of the PR, not all the interim work used to implement it.
+
+- when merging a PR provide a clean commit message using semntic commit
+  message style.  Do no just use the default message or a concatenation
+  of all the commit messages.  The message should reflect the scope and
+  logical content of the PR, not all the interim work used to implement
+  it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,18 @@ clj
 clj-kondo --lint src test
 ```
 
+**Build:**
+```bash
+# Build JAR (creates target/mcp-tasks-<version>.jar)
+clj -T:build jar
+
+# Clean build artifacts
+clj -T:build clean
+
+# Check version
+clj -T:build version
+```
+
 ## Key Concepts
 
 - **Categories**: Organize tasks by type/purpose, each with custom execution instructions

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,3 +53,4 @@ clj-kondo --lint src test
 ───────────────────────────────────────────────────────────────────────────────────────
   # to memorize                                                         ⧉ In main.clj
 - run `clj-kondo --lint src test` before commiting
+- when merging a PR provide a clean commit message using semntic commit message style.  Do no just use the default message or a concatenation of all the commit messages.  The message should reflect the scope and logical content of the PR, not all the interim work used to implement it.

--- a/deps.edn
+++ b/deps.edn
@@ -1,14 +1,18 @@
 {:deps
- {org.hugpduncan/mcp-clj {:git/url   "https://github.com/hugoduncan/mcp-clj"
-                          :git/sha   "77ca1a2df2c9d261a127272417e92e0728b528fd"
+ {org.hugpduncan/mcp-clj {:git/url "https://github.com/hugoduncan/mcp-clj"
+                          :git/sha "77ca1a2df2c9d261a127272417e92e0728b528fd"
                           :deps/root "projects/server"}
-  org.clojure/clojure    {:mvn/version "1.12.3"}}
+  org.clojure/clojure {:mvn/version "1.12.3"}}
 
  :aliases
- {:dev   {}
-  :test  {:extra-paths ["test"]
-          :extra-deps  {lambdaisland/kaocha {:mvn/version "1.91.1392"}}
-          :main-opts   ["-m" "kaocha.runner"]}
-  :run   {:exec-fn mcp-tasks.main/start}
+ {:dev {}
+  :test {:extra-paths ["test"]
+         :extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}}
+         :main-opts ["-m" "kaocha.runner"]}
+  :run {:exec-fn mcp-tasks.main/start
+        :main-opts ["-m" "mcp-tasks.main"]}
   :nrepl {:extra-deps {nrepl/nrepl {:mvn/version "1.0.0"}}
-          :main-opts  ["-m" "nrepl.cmdline"]}}}
+          :main-opts ["-m" "nrepl.cmdline"]}
+  :build {:deps {io.github.clojure/tools.build {:mvn/version "0.10.5"}}
+          :paths ["dev"]
+          :ns-default build}}}

--- a/dev/build.clj
+++ b/dev/build.clj
@@ -1,0 +1,41 @@
+(ns build
+  (:require
+    [clojure.tools.build.api :as b]))
+
+(def lib 'org.hugoduncan/mcp-tasks)
+(def version-base "0.1")
+(def target-dir "target")
+(def class-dir (str target-dir "/classes"))
+
+(defn version
+  "Calculate version from git commit count"
+  [_]
+  (let [commit-count (b/git-count-revs nil)
+        v (format "%s.%s" version-base commit-count)]
+    (println "Version:" v)
+    v))
+
+(defn clean
+  "Remove target directory"
+  [_]
+  (println "Cleaning target directory...")
+  (b/delete {:path target-dir}))
+
+(defn jar
+  "Build JAR file with Main-Class manifest"
+  [_]
+  (let [v (version nil)
+        basis (b/create-basis {:project "deps.edn"})
+        jar-file (format "%s/mcp-tasks-%s.jar" target-dir v)]
+    (println "Building JAR:" jar-file)
+    (b/write-pom {:class-dir class-dir
+                  :lib lib
+                  :version v
+                  :basis basis
+                  :src-dirs ["src"]})
+    (b/copy-dir {:src-dirs ["src"]
+                 :target-dir class-dir})
+    (b/jar {:class-dir class-dir
+            :jar-file jar-file
+            :main 'mcp-tasks.main})
+    (println "JAR built successfully:" jar-file)))


### PR DESCRIPTION
## Summary
- Added tools.build script for building executable JAR files
- Configured automatic version numbering based on git commit count (format: 0.1.<commits>)
- Added build commands documentation to CLAUDE.md

## Changes
- Created `dev/build.clj` with `version`, `clean`, and `jar` functions
- Added `:build` alias to `deps.edn` with tools.build dependency
- Updated `CLAUDE.md` with build command documentation

## Usage
```bash
# Build JAR
clj -T:build jar

# Clean build artifacts  
clj -T:build clean

# Check version
clj -T:build version
```

## Test plan
- [x] Build JAR successfully creates `target/mcp-tasks-<version>.jar`
- [x] JAR manifest includes Main-Class: mcp_tasks.main
- [x] Version automatically calculated from git commit count
- [x] Clean command removes target directory
- [x] All tests pass