### PR TITLE
feat: add prepend option to add-task tool

### DIFF
--- a/src/mcp_tasks/tools.clj
+++ b/src/mcp_tasks/tools.clj
@@ -204,15 +204,22 @@
 (defn add-task-impl
   "Implementation of add-task tool.
 
-  Appends a task to tasks/<category>.md as an incomplete todo item."
-  [{:keys [category task-text]}]
+  Adds a task to tasks/<category>.md as an incomplete todo item.
+  If prepend is true, adds at the beginning; otherwise appends at the end."
+  [{:keys [category task-text prepend]}]
   (try
     (let [tasks-dir     ".mcp-tasks/tasks"
           tasks-file    (str tasks-dir "/" category ".md")
           tasks-content (read-task-file tasks-file)
           new-task      (str "- [ ] " task-text)
-          new-content   (if (str/blank? tasks-content)
+          new-content   (cond
+                          (str/blank? tasks-content)
                           new-task
+
+                          prepend
+                          (str new-task "\n" tasks-content)
+
+                          :else
                           (str tasks-content "\n" new-task))]
       (write-task-file tasks-file new-content)
       {:content [{:type "text"
@@ -237,6 +244,9 @@
       :description "The task category name"}
      "task-text"
      {:type        "string"
-      :description "The task text to add"}}
+      :description "The task text to add"}
+     "prepend"
+     {:type        "boolean"
+      :description "If true, add task at the beginning instead of the end"}}
     :required ["category" "task-text"]}
    :implementation add-task-impl})

--- a/test/mcp_tasks/tools_test.clj
+++ b/test/mcp_tasks/tools_test.clj
@@ -295,3 +295,33 @@
            (is (= "- [ ] first line\nsecond line"
                   (read-test-file "tasks/test.md")))))
       (cleanup-test-fixtures))))
+
+(deftest add-task-prepends-when-prepend-is-true
+  ;; Tests that add-task-impl prepends task when prepend option is true
+  (testing "add-task"
+    (testing "prepends task when prepend is true"
+      (setup-test-dir)
+      (write-test-file "tasks/test.md" "- [ ] existing task")
+      (with-test-files
+        #(let [result (sut/add-task-impl {:category "test"
+                                          :task-text "new task"
+                                          :prepend true})]
+           (is (false? (:isError result)))
+           (is (= "- [ ] new task\n- [ ] existing task"
+                  (read-test-file "tasks/test.md")))))
+      (cleanup-test-fixtures))))
+
+(deftest add-task-prepends-to-empty-file-when-prepend-is-true
+  ;; Tests that add-task-impl works correctly with empty file and prepend option
+  (testing "add-task"
+    (testing "prepends to empty file when prepend is true"
+      (setup-test-dir)
+      (write-test-file "tasks/test.md" "")
+      (with-test-files
+        #(let [result (sut/add-task-impl {:category "test"
+                                          :task-text "new task"
+                                          :prepend true})]
+           (is (false? (:isError result)))
+           (is (= "- [ ] new task"
+                  (read-test-file "tasks/test.md")))))
+      (cleanup-test-fixtures))))


### PR DESCRIPTION
## Summary
- Added optional `prepend` parameter to `add-task` tool
- Tasks can now be added at the beginning of the file instead of the end
- Updated tool schema and added comprehensive test coverage

## Changes
- Modified `add-task-impl` to accept optional `prepend` parameter
- Updated `add-task-tool` schema with prepend option description
- Added tests for prepending to empty and non-empty files

## Test plan
- [x] All existing tests pass
- [x] New tests verify prepending to empty files
- [x] New tests verify prepending to non-empty files
- [x] cljstyle and clj-kondo checks pass