### PR TITLE
fix: update native binary test count and add hooks resources

### DIFF
--- a/resources/META-INF/native-image/org.hugoduncan/mcp-tasks/resource-config.json
+++ b/resources/META-INF/native-image/org.hugoduncan/mcp-tasks/resource-config.json
@@ -9,6 +9,9 @@
       },
       {
         "pattern": "prompts/infrastructure/.*\\.md"
+      },
+      {
+        "pattern": "hooks/.*\\.bb"
       }
     ]
   }

--- a/test/mcp_tasks/native_binary_integration_test.clj
+++ b/test/mcp_tasks/native_binary_integration_test.clj
@@ -391,9 +391,9 @@
       (let [result (call-binary "prompts" "install")]
         (is (= 0 (:exit result))
             (format "Exit code should be 0. Actual: %s" (:exit result)))
-        ;; Should report 13 files generated (8 workflows + 5 categories)
-        (is (str/includes? (:out result) "13")
-            (format "Should report generating 13 slash command files. Output: %s" (:out result)))))))
+        ;; Should report 14 files generated (9 workflows + 5 categories)
+        (is (str/includes? (:out result) "14")
+            (format "Should report generating 14 slash command files. Output: %s" (:out result)))))))
 
 (deftest ^:native-binary ^:comprehensive comprehensive-prompts-customize
   ;; Test that prompts customize command copies prompts correctly


### PR DESCRIPTION
## Summary
- Update test to expect 14 prompts (9 workflows + 5 categories) after review-task-implementation was added
- Add hooks/*.bb pattern to resource-config.json for native image so hooks can be installed

## Test plan
- [ ] CI passes with native binary tests
- [ ] Release workflow succeeds