### PR TITLE
fix: pass start-dir to resolve-config in CLI work-on

### DIFF
--- a/src/mcp_tasks/cli.clj
+++ b/src/mcp_tasks/cli.clj
@@ -149,8 +149,8 @@
 
                    ;; Execute valid command
                    :else
-                   (let [{:keys [raw-config config-dir]} (config/read-config)
-                         resolved-config (config/resolve-config config-dir raw-config)
+                   (let [{:keys [raw-config config-dir start-dir]} (config/read-config)
+                         resolved-config (config/resolve-config config-dir raw-config start-dir)
                          _ (config/validate-startup config-dir resolved-config)]
                      (execute-command resolved-config command command-args format)))]
 

--- a/test/mcp_tasks/cli_integration_test.clj
+++ b/test/mcp_tasks/cli_integration_test.clj
@@ -1258,11 +1258,11 @@
           (let [parsed (read-string (:out result))]
             (is (= 1 (:task-id parsed)))
             (is (= "Child dir task" (:title parsed)))
-            (is (some? (:execution-state-file parsed)))))
+            (is (some? (:execution-state-file parsed))))
 
-        (testing "writes execution state to child directory"
-          (let [state-file (io/file child-dir ".mcp-tasks-current.edn")]
-            (is (.exists state-file)
-                "Execution state should be in child directory")
-            (let [state (read-string (slurp state-file))]
-              (is (= 1 (:task-id state))))))))))
+          (testing "writes execution state to child directory"
+            (let [state-file (io/file child-dir ".mcp-tasks-current.edn")]
+              (is (.exists state-file)
+                  "Execution state should be in child directory")
+              (let [state (read-string (slurp state-file))]
+                (is (= 1 (:task-id state)))))))))))


### PR DESCRIPTION
## Summary

Fixes `work-on` failing with "not a git repository" when run from a project directory whose `.mcp-tasks.edn` config is inherited from a parent directory.

- Pass `:start-dir` from `read-config` to `resolve-config` in the CLI, matching how `main.clj` already handles it
- Add integration test verifying `work-on` succeeds from a child git directory with config in a parent
- Refactor `call-cli` helper to accept an optional directory parameter

## Test plan

- [x] Integration test: config in parent dir, git repo in child dir, verify work-on succeeds
- [x] All existing tests pass
- [x] clj-kondo lint clean